### PR TITLE
Fix handling of namespaces in multi-threaded processes.

### DIFF
--- a/netns_test.go
+++ b/netns_test.go
@@ -2,6 +2,7 @@ package netns
 
 import (
 	"runtime"
+	"sync"
 	"testing"
 )
 
@@ -41,4 +42,25 @@ func TestNone(t *testing.T) {
 	if ns.IsOpen() {
 		t.Fatal("None ns is open", ns)
 	}
+}
+
+func TestThreaded(t *testing.T) {
+	ncpu := runtime.GOMAXPROCS(-1)
+	if ncpu < 2 {
+		t.Skip("-cpu=2 or larger required")
+	}
+
+	// Lock this thread simply to ensure other threads get used.
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i < ncpu; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			TestGetNewSetDelete(t)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
GetFromPid gets the namespace of the main thread, so previously Get
returned the wrong value if run from any other thread. Add a new
GetFromThread which uses the Linux thread id and switch Get to it.