### PR TITLE
Add Build Flags

### DIFF
--- a/netns.go
+++ b/netns.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"syscall"
 )
+
 // NsHandle is a handle to a network namespace. It can be cast directly
 // to an int and used as a file descriptor.
 type NsHandle int

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package netns
 
 import (

--- a/netns_linux_386.go
+++ b/netns_linux_386.go
@@ -1,3 +1,5 @@
+// +build linux,386
+
 package netns
 
 const (

--- a/netns_linux_amd64.go
+++ b/netns_linux_amd64.go
@@ -1,3 +1,5 @@
+// +build linux,amd64
+
 package netns
 
 const (

--- a/netns_linux_arm.go
+++ b/netns_linux_arm.go
@@ -1,3 +1,5 @@
+// +build linux,arm
+
 package netns
 
 const (

--- a/netns_unspecified.go
+++ b/netns_unspecified.go
@@ -10,26 +10,26 @@ var (
 	ErrNotImplemented = errors.New("not implemented")
 )
 
-func Set(ns Namespace) (err error) {
+func Set(ns NsHandle) (err error) {
 	return ErrNotImplemented
 }
 
-func New() (ns Namespace, err error) {
+func New() (ns NsHandle, err error) {
 	return -1, ErrNotImplemented
 }
 
-func Get() (Namespace, error) {
+func Get() (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromName(name string) (Namespace, error) {
+func GetFromName(name string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromPid(pid int) (Namespace, error) {
+func GetFromPid(pid int) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromDocker(id string) (Namespace, error) {
+func GetFromDocker(id string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }


### PR DESCRIPTION
This commit adds build flags for the various architectures to prevent
failures when cross compiling. It also fixes errors in
netns_unspecified.go by replacing the undefined type Namespace with
NsHandle

Signed-off-by: Dave Tucker <dt@docker.com>