### PR TITLE
Add syscall id for Powerpc(ppc64) Little Endian(LE) architecture

### DIFF
--- a/netns_linux_ppc64le.go
+++ b/netns_linux_ppc64le.go
@@ -1,0 +1,7 @@
+// +build linux,ppc64le
+
+package netns
+
+const (
+	SYS_SETNS = 350
+)


### PR DESCRIPTION
Add syscall id for Powerpc(ppc64) Little Endian(LE) architecture
Signed-of-by: Pradipta Kr. Banerjee <pradipta.banerjee@gmail.com>