### PR TITLE
Add support for arm64

### DIFF
--- a/netns_linux_arm64.go
+++ b/netns_linux_arm64.go
@@ -1,0 +1,7 @@
+// +build linux,arm64
+
+package netns
+
+const (
+	SYS_SETNS = 375
+)


### PR DESCRIPTION
This should fix the issues seen in docker/libnetwork#198

Signed-off-by: Dave Tucker <dt@docker.com>