### PR TITLE
Container cgroup location under systemd

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -170,7 +170,7 @@ func getPidForContainer(id string) (int, error) {
 		// With more recent docker, cgroup will be in docker/
 		filepath.Join(cgroupRoot, cgroupThis, "docker", id, "tasks"),
 		// Even more recent docker versions under systemd use docker-<id>.scope/
-		filepath.Join(cgroupRoot, cgroupThis, "docker-" + id + ".scope", tasks"),
+		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope", "tasks"),
 	}
 
 	var filename string

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -167,8 +167,10 @@ func getPidForContainer(id string) (int, error) {
 		filepath.Join(cgroupRoot, cgroupThis, id, "tasks"),
 		// With more recent lxc versions use, cgroup will be in lxc/
 		filepath.Join(cgroupRoot, cgroupThis, "lxc", id, "tasks"),
-		// With more recent dockee, cgroup will be in docker/
+		// With more recent docker, cgroup will be in docker/
 		filepath.Join(cgroupRoot, cgroupThis, "docker", id, "tasks"),
+		// Even more recent docker versions under systemd use docker-<id>.scope/
+		filepath.Join(cgroupRoot, cgroupThis, "docker-" + id + ".scope", tasks"),
 	}
 
 	var filename string


### PR DESCRIPTION
In recent version of docker (I can't seem to find when), docker has started placing the cgroup in a different location if running under systemd.

```
/sys/fs/cgroup/memory/system.slice/docker-<ID>.scope/tasks
```

This pull supports this scenario.