### PR TITLE
Added function UniqueId which returns a string that uniquely identifies namespace

### DIFF
--- a/netns.go
+++ b/netns.go
@@ -46,6 +46,19 @@ func (ns NsHandle) String() string {
 	return fmt.Sprintf("NS(%d: %d, %d)", ns, s.Dev, s.Ino)
 }
 
+// UniqueId returns a string which uniquely identifies the namespace
+// associated with the network handle.
+func (ns NsHandle) UniqueId() string {
+	var s syscall.Stat_t
+	if ns == -1 {
+		return "NS(none)"
+	}
+	if err := syscall.Fstat(int(ns), &s); err != nil {
+		return "NS(unknown)"
+	}
+	return fmt.Sprintf("NS(%d:%d)", s.Dev, s.Ino)
+}
+
 // IsOpen returns true if Close() has not been called.
 func (ns NsHandle) IsOpen() bool {
 	return ns != -1


### PR DESCRIPTION
I have a use case where I'd like to uniquely identify a network namespace given a netns handle. The netns handle itself does this job but also keeps the associated file handle open. The proposed function UniqueId returns a string identifier which uniquely identifies the network namespace (using the inode and dev keys similar to the Equal comparison function). The caller can then choose to close the handle and still hold on to the unique string identifier.