### PR TITLE
Typo: fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ func main() {
     newns, _ := netns.New()
     defer newns.Close()
 
-    // Do something with tne network namespace
+    // Do something with the network namespace
     ifaces, _ := net.Interfaces()
     fmt.Printf("Interfaces: %v\n", ifaces)
 


### PR DESCRIPTION
I think the `tne` should be `the`
Signed-off-by: Lei Jitang <leijitang@huawei.com>