### PR TITLE
Add missing stub functions to netns_unspecified.go

### DIFF
--- a/netns_unspecified.go
+++ b/netns_unspecified.go
@@ -22,11 +22,19 @@ func Get() (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
+func GetFromPath(path string) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
 func GetFromName(name string) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
 func GetFromPid(pid int) (NsHandle, error) {
+	return -1, ErrNotImplemented
+}
+
+func GetFromThread(pid, tid int) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 


### PR DESCRIPTION
Turns out we need GetFromPath() for https://github.com/NetSys/quilt, so I went ahead and add it as well as GetFromThread()