### PR TITLE
Search kubepods for Docker containers

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -188,6 +188,8 @@ func getPidForContainer(id string) (int, error) {
 		filepath.Join(cgroupRoot, "system.slice", "docker-"+id+".scope", "tasks"),
 		// Even more recent docker versions under cgroup/systemd/docker/<id>/
 		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, "tasks"),
+		// Kubernetes with docker and CNI is even more different
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, "tasks"),
 	}
 
 	var filename string


### PR DESCRIPTION
When using Kubernetes with CNI and Docker, the cgroup entries are
dropped in yet another creative place. This adds yet another attempt
to locate the container within `kubepods`.