### PR TITLE
Adding new location for containers in recent k8s 1.11+

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -190,6 +190,8 @@ func getPidForContainer(id string) (int, error) {
 		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, "tasks"),
 		// Kubernetes with docker and CNI is even more different
 		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, "tasks"),
+		// Another flavor of containers location in recent kubernetes 1.11+
+		filepath.Join(cgroupRoot, cgroupThis, "kubepods.slice", "kubepods-besteffort.slice", "*", "docker-"+id+".scope", "tasks"),
 	}
 
 	var filename string


### PR DESCRIPTION
This PR add a new location used by recent version of kubernetes to place docker containers.
```
/sys/fs/cgroup/memory/kubepods.slice/kubepods-besteffort.slice/*
```
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>