### PR TITLE
In contaner path fix

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -192,6 +192,8 @@ func getPidForContainer(id string) (int, error) {
 		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, "tasks"),
 		// Another flavor of containers location in recent kubernetes 1.11+
 		filepath.Join(cgroupRoot, cgroupThis, "kubepods.slice", "kubepods-besteffort.slice", "*", "docker-"+id+".scope", "tasks"),
+		// When runs inside of a container with recent kubernetes 1.11+
+		filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-besteffort.slice", "*", "docker-"+id+".scope", "tasks"),
 	}
 
 	var filename string


### PR DESCRIPTION
When the process attempting to get namespace by using GetFromDocker, running in Docker container, the path to the list of containers is:
`groupRoot, "kubepods.slice", "kubepods-besteffort.slice", "*", "docker-"+id+".scope", "tasks"`

Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>