### PR TITLE
Add go1.10 build constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ func main() {
 }
 
 ```
+
+## NOTE
+
+The library can be safely used only with Go >= 1.10 due to [golang/go#20676](https://github.com/golang/go/issues/20676).
+
+After locking a goroutine to its current OS thread with `runtime.LockOSThread()`
+and changing its network namespace, any new subsequent goroutine won't be
+scheduled on that thread while it's locked. Therefore, the new goroutine
+will run in a different namespace leading to unexpected results.
+
+See [here](https://www.weave.works/blog/linux-namespaces-golang-followup) for more details.

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux,go1.10
 
 package netns
 


### PR DESCRIPTION
This prevents netns from being used on older Go runtimes on which it's not safe to perform any state manipulations of a scheduling thread (https://github.com/golang/go/issues/20676).

Partially fixes #17.