### PR TITLE
Remove useless setting of new netns from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ func main() {
 
     // Create a new network namespace
     newns, _ := netns.New()
-    netns.Set(newns)
     defer newns.Close()
 
     // Do something with the network namespace


### PR DESCRIPTION
Remove from the README.md example the instruction which explicitly sets
the newly created netns as the netns of the current OS Thread. The removed
instruction is not needed because the setting is implicitly done by netns.New().