### PR TITLE
add ns support mips64le arch

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -21,6 +21,7 @@ var SYS_SETNS = map[string]uintptr{
 	"arm":     375,
 	"mips":    4344,
 	"mipsle":  4344,
+	"mips64le":  4344,
 	"ppc64":   350,
 	"ppc64le": 350,
 	"s390x":   339,


### PR DESCRIPTION
go env info
[root@node152 weaver]# go env
GOARCH="mips64le"
GOBIN=""
GOCACHE="/root/.cache/go-build"
GOEXE=""
GOHOSTARCH="mips64le"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/root/goworkspace"
GORACE=""
GOROOT="/home/longxin/workspace/go"
GOTMPDIR=""
GOTOOLDIR="/home/longxin/workspace/go/pkg/tool/linux_mips64le"
GCCGO="gccgo"
CC="gcc"
CXX="g++"
CGO_ENABLED="1"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -mabi=64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build929428261=/tmp/go-build -gno-record-gcc-switches"