### PR TITLE
Use golang.org/x/sys/unix instead of syscall

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/vishvananda/netns
 
 go 1.12
+
+require golang.org/x/sys v0.0.0-20200217220822-9197077df867

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.0.0-20200217220822-9197077df867 h1:JoRuNIf+rpHl+VhScRQQvzbHed86tKkqwPMV34T8myw=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
The syscall package is deprecated and no longer updated as per
https://golang.org/pkg/syscall/. Use the golang.org/x/sys/unix package
instead, which also provides a wrapper for `SYS_SETNS`, so the syscall
number encoding depending on `runtime.GOARCH` can be dropped.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>