### PR TITLE
Set O_CLOEXEC when opening a network namespace

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -52,7 +52,7 @@ func Get() (NsHandle, error) {
 // GetFromPath gets a handle to a network namespace
 // identified by the path
 func GetFromPath(path string) (NsHandle, error) {
-	fd, err := unix.Open(path, unix.O_RDONLY, 0)
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Set O_CLOEXEC when opening a network namespace

Fix: [moby/moby/issues/41136](https://github.com/moby/moby/issues/41136)
the container‘s netns fds leak, causing the container netns to not clean up successfully after the container stop


Signed-off-by: fanjiyun <fan.jiyun@zte.com.cn>