### PR TITLE
Fixed the k8s docker netns detection err when pod QOS is Guaranteed

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -220,6 +220,8 @@ func getPidForContainer(id string) (int, error) {
 		filepath.Join(cgroupRoot, "..", "systemd", "docker", id, "tasks"),
 		// Kubernetes with docker and CNI is even more different
 		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "*", "pod*", id, "tasks"),
+		// Kubernetes with docker and CNI is even more different when QOS is Guaranteed
+		filepath.Join(cgroupRoot, "..", "systemd", "kubepods", "pod*", id, "tasks"),
 		// Another flavor of containers location in recent kubernetes 1.11+
 		filepath.Join(cgroupRoot, cgroupThis, "kubepods.slice", "kubepods-besteffort.slice", "*", "docker-"+id+".scope", "tasks"),
 		// When runs inside of a container with recent kubernetes 1.11+


### PR DESCRIPTION
With k8s 1.14.6 and docker 18.09.9, the docker netns detection 
funtion failed to look for the Pod's container task file when Pod QOS is  Guaranteed. This 
change fixed the issue.
When the QOS is Guaranteed the cgroup under cgroup/systemd/kubepods/pod* not under cgroup/systemd/kubepods/{besteffort,burstable}/pod*