### PR TITLE
go.mod: update minimum version to go1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/vishvananda/netns
 
-go 1.12
+go 1.17
 
 require golang.org/x/sys v0.2.0

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -2,7 +2,6 @@ package netns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -136,7 +135,7 @@ func GetFromDocker(id string) (NsHandle, error) {
 
 // borrowed from docker/utils/utils.go
 func findCgroupMountpoint(cgroupType string) (int, string, error) {
-	output, err := ioutil.ReadFile("/proc/mounts")
+	output, err := os.ReadFile("/proc/mounts")
 	if err != nil {
 		return -1, "", err
 	}
@@ -166,7 +165,7 @@ func findCgroupMountpoint(cgroupType string) (int, string, error) {
 // borrowed from docker/utils/utils.go
 // modified to get the docker pid instead of using /proc/self
 func getDockerCgroup(cgroupVer int, cgroupType string) (string, error) {
-	dockerpid, err := ioutil.ReadFile("/var/run/docker.pid")
+	dockerpid, err := os.ReadFile("/var/run/docker.pid")
 	if err != nil {
 		return "", err
 	}
@@ -178,7 +177,7 @@ func getDockerCgroup(cgroupVer int, cgroupType string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	output, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	output, err := os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err
 	}
@@ -265,7 +264,7 @@ func getPidForContainer(id string) (int, error) {
 		return pid, fmt.Errorf("Unable to find container: %v", id[:len(id)-1])
 	}
 
-	output, err := ioutil.ReadFile(filename)
+	output, err := os.ReadFile(filename)
 	if err != nil {
 		return pid, err
 	}


### PR DESCRIPTION
golang.org/x/sys now requires go1.17 as a minimum, and otherwise fails:

    Error: ../../../go/pkg/mod/golang.org/x/sys@v0.2.0/unix/syscall.go:83:16: undefined: unsafe.Slice
    Error: ../../../go/pkg/mod/golang.org/x/sys@v0.2.0/unix/syscall_linux.go:2256:9: undefined: unsafe.Slice
    Error: ../../../go/pkg/mod/golang.org/x/sys@v0.2.0/unix/syscall_unix.go:118:7: undefined: unsafe.Slice
    Error: ../../../go/pkg/mod/golang.org/x/sys@v0.2.0/unix/sysvshm_unix.go:33:7: undefined: unsafe.Slice

unsafe.Slice was added in go1.17; https://pkg.go.dev/unsafe#Slice

Now that go1.17 is the minimum version, we cal also replace the deprecated io/ioutil package (which was deprecated in go1.16).

