### PR TITLE
Drop note about `go` `1.10` compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,3 @@ func main() {
 }
 
 ```
-
-## NOTE
-
-The library can be safely used only with Go >= 1.10 due to [golang/go#20676](https://github.com/golang/go/issues/20676).
-
-After locking a goroutine to its current OS thread with `runtime.LockOSThread()`
-and changing its network namespace, any new subsequent goroutine won't be
-scheduled on that thread while it's locked. Therefore, the new goroutine
-will run in a different namespace leading to unexpected results.
-
-See [here](https://www.weave.works/blog/linux-namespaces-golang-followup) for more details.


### PR DESCRIPTION
Now that we require `go` `1.17`, this note is no longer relevant.