### PR TITLE
code clean for the Ns(none) return string.

### DIFF
--- a/nshandle_linux.go
+++ b/nshandle_linux.go
@@ -30,7 +30,7 @@ func (ns NsHandle) Equal(other NsHandle) bool {
 // String shows the file descriptor number and its dev and inode.
 func (ns NsHandle) String() string {
 	if ns == -1 {
-		return "NS(None)"
+		return "NS(none)"
 	}
 	var s unix.Stat_t
 	if err := unix.Fstat(int(ns), &s); err != nil {

--- a/nshandle_others.go
+++ b/nshandle_others.go
@@ -17,7 +17,7 @@ func (ns NsHandle) Equal(_ NsHandle) bool {
 // It is only implemented on Linux, and returns "NS(none)" on other
 // platforms.
 func (ns NsHandle) String() string {
-	return "NS(None)"
+	return "NS(none)"
 }
 
 // UniqueId returns a string which uniquely identifies the namespace


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>

Should we unify the return string ,like "NS(none)"??