### PR TITLE
ci(lint): enable errcheck, errorlint, gci, misspell, nonamedreturns and staticcheck linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 linters:
   enable:
     - errorlint
+    - misspell
 
 run:
   timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,15 @@
 linters:
   enable:
     - errorlint
+    - gci
     - misspell
+
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/vishvananda)
 
 run:
   timeout: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,11 @@
 linters:
   enable:
+    - errcheck
     - errorlint
     - gci
     - misspell
+    - nonamedreturns
+    - staticcheck
 
 linters-settings:
   gci:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,2 +1,6 @@
+linters:
+  enable:
+    - errorlint
+
 run:
   timeout: 5m

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -26,19 +26,19 @@ const bindMountPath = "/run/netns" /* Bind mount path for named netns */
 // Setns sets namespace using golang.org/x/sys/unix.Setns.
 //
 // Deprecated: Use golang.org/x/sys/unix.Setns instead.
-func Setns(ns NsHandle, nstype int) (err error) {
+func Setns(ns NsHandle, nstype int) error {
 	return unix.Setns(int(ns), nstype)
 }
 
 // Set sets the current network namespace to the namespace represented
 // by NsHandle.
-func Set(ns NsHandle) (err error) {
+func Set(ns NsHandle) error {
 	return unix.Setns(int(ns), unix.CLONE_NEWNET)
 }
 
 // New creates a new network namespace, sets it as current and returns
 // a handle to it.
-func New() (ns NsHandle, err error) {
+func New() (NsHandle, error) {
 	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
 		return -1, err
 	}

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -276,7 +276,7 @@ func getPidForContainer(id string) (int, error) {
 
 	pid, err = strconv.Atoi(result[0])
 	if err != nil {
-		return pid, fmt.Errorf("Invalid pid '%s': %s", result[0], err)
+		return pid, fmt.Errorf("Invalid pid '%s': %w", result[0], err)
 	}
 
 	return pid, nil

--- a/netns_others.go
+++ b/netns_others.go
@@ -15,15 +15,15 @@ var (
 // is not implemented on other platforms.
 //
 // Deprecated: Use golang.org/x/sys/unix.Setns instead.
-func Setns(ns NsHandle, nstype int) (err error) {
+func Setns(ns NsHandle, nstype int) error {
 	return ErrNotImplemented
 }
 
-func Set(ns NsHandle) (err error) {
+func Set(ns NsHandle) error {
 	return ErrNotImplemented
 }
 
-func New() (ns NsHandle, err error) {
+func New() (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
@@ -51,7 +51,7 @@ func GetFromPid(pid int) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 
-func GetFromThread(pid, tid int) (NsHandle, error) {
+func GetFromThread(pid int, tid int) (NsHandle, error) {
 	return -1, ErrNotImplemented
 }
 

--- a/nshandle_others.go
+++ b/nshandle_others.go
@@ -9,7 +9,7 @@ type NsHandle int
 
 // Equal determines if two network handles refer to the same network
 // namespace. It is only implemented on Linux.
-func (ns NsHandle) Equal(ns NsHandle) bool {
+func (ns NsHandle) Equal(_ NsHandle) bool {
 	return false
 }
 

--- a/nshandle_others.go
+++ b/nshandle_others.go
@@ -9,7 +9,7 @@ type NsHandle int
 
 // Equal determines if two network handles refer to the same network
 // namespace. It is only implemented on Linux.
-func (ns NsHandle) Equal(_ NsHandle) bool {
+func (ns NsHandle) Equal(ns NsHandle) bool {
 	return false
 }
 


### PR DESCRIPTION
Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>