### PR TITLE
enable gocritic, gosec, gosimple, govet, unconvert, unparam, unused and whitespace linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,10 +2,18 @@ linters:
   enable:
     - errcheck
     - errorlint
+    - gocritic
+    - gosec
+    - gosimple
+    - govet
     - gci
     - misspell
     - nonamedreturns
     - staticcheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
 
 linters-settings:
   gci:

--- a/netns_linux.go
+++ b/netns_linux.go
@@ -49,7 +49,7 @@ func New() (NsHandle, error) {
 // and returns a handle to it
 func NewNamed(name string) (NsHandle, error) {
 	if _, err := os.Stat(bindMountPath); os.IsNotExist(err) {
-		err = os.MkdirAll(bindMountPath, 0755)
+		err = os.MkdirAll(bindMountPath, 0o755)
 		if err != nil {
 			return None(), err
 		}
@@ -62,7 +62,7 @@ func NewNamed(name string) (NsHandle, error) {
 
 	namedPath := path.Join(bindMountPath, name)
 
-	f, err := os.OpenFile(namedPath, os.O_CREATE|os.O_EXCL, 0444)
+	f, err := os.OpenFile(namedPath, os.O_CREATE|os.O_EXCL, 0o444)
 	if err != nil {
 		newNs.Close()
 		return None(), err
@@ -217,11 +217,12 @@ func getPidForContainer(id string) (int, error) {
 	id += "*"
 
 	var pidFile string
-	if cgroupVer == 1 {
+	switch cgroupVer {
+	case 1:
 		pidFile = "tasks"
-	} else if cgroupVer == 2 {
+	case 2:
 		pidFile = "cgroup.procs"
-	} else {
+	default:
 		return -1, fmt.Errorf("Invalid cgroup version '%d'", cgroupVer)
 	}
 

--- a/netns_others.go
+++ b/netns_others.go
@@ -3,13 +3,9 @@
 
 package netns
 
-import (
-	"errors"
-)
+import "errors"
 
-var (
-	ErrNotImplemented = errors.New("not implemented")
-)
+var ErrNotImplemented = errors.New("not implemented")
 
 // Setns sets namespace using golang.org/x/sys/unix.Setns on Linux. It
 // is not implemented on other platforms.


### PR DESCRIPTION
Enable the following linters:

- gocritic
- gosec
- gosimple
- govet
- unconvert
- unparam
- unused
- whitespace

Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com>