### PR TITLE
Fix a race condition in `netns.New`

### DIFF
--- a/netns_linux.go
+++ b/netns_linux.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -39,6 +40,8 @@ func Set(ns NsHandle) error {
 // New creates a new network namespace, sets it as current and returns
 // a handle to it.
 func New() (NsHandle, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
 	if err := unix.Unshare(unix.CLONE_NEWNET); err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
I'm working on a project that uses `netns`, and I noticed that one of our integration tests was flaky. I traced the issue to a race in `netns.New`. The issue is that the Go scheduler might move the current goroutine to a different OS thread after the new namespace has been created (and joined), but before the call to `Get()`. When this happens, the wrong namespace handle is returned.