### PR TITLE
Recommend running tests with unshare

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can use go get command:
 
 Testing (requires root):
 
-    sudo -E go test github.com/vishvananda/netns
+    unshare -rn go test github.com/vishvananda/netns
 
 ## Example ##
 


### PR DESCRIPTION
As it is a lot safer than running them with sudo. It cannot affect the current network namespace by mistake and it also allows not to use the real root user which enforces fs permissions.

See also: https://blog.0x1b.me/posts/unprivileged-linux-netns-pt1/