### PR TITLE
Bump to go 1.23 as min version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,12 +20,8 @@ jobs:
     strategy:
       matrix:
         # test against the "oldest" supported version and the current version
-        # of go. Go 1.17 is kept in this matrix as it is the minimum version
-        # specified in go.mod, and maintaining compatibility with go 1.17 is
-        # currently not much of a burden. Most projects using this module are
-        # using newer versions than that, so we can drop the old version if
-        # it becomes too much of a burden.
-        go-version: [1.17.x, stable]
+        # of go.
+        go-version: [1.23.x, stable]
         os: [ubuntu-24.04, ubuntu-22.04, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/vishvananda/netns
 
-go 1.17
+go 1.23
 
 require golang.org/x/sys v0.2.0


### PR DESCRIPTION
We don't technically need this new of a bump, but this library has been very stable and this bump will only apply to new versions... so anyone who is running an older version of go can use the old stable releases of this library.

The harder thing is finding maintainer time to keep up with things... for example, we've been on go 1.17 for years... so might as well bump this to 1.23 as 1.25 will be out soon... and this also let us use the `go mod tidy -diff` functionality.

Again, we can revert this if someone really needs a backport to an older version of go... but 🤷‍♂️ I doubt anyone will.